### PR TITLE
Make the installation of epel-release configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,10 @@
 #   - $package_name [type: string]
 #     Name of the installation package, defaults to 'cobbler'
 #
+#   - $use_epel [type: bool]
+#     Wether to install epel-release or not. Defaults to true. If not using epel
+#     you have to provide a yumrepo with the cobbler rpm by yourself.
+#
 #   - $package_ensure [type: string]
 #     Defaults to 'present', buy any version can be set
 #
@@ -93,6 +97,7 @@ class cobbler (
   $service_name       = $cobbler::params::service_name,
   $package_name       = $cobbler::params::package_name,
   $package_ensure     = $cobbler::params::package_ensure,
+  $use_epel           = $cobbler::params::use_epel,
   $distro_path        = $cobbler::params::distro_path,
   $manage_dhcp        = $cobbler::params::manage_dhcp,
   $dhcp_dynamic_range = $cobbler::params::dhcp_dynamic_range,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class cobbler::params {
     'RedHat': {
       $service_name = 'cobblerd'
       $package_name = 'cobbler'
+      $use_epel = true
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports osfamily RedHat")

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -1,7 +1,11 @@
 class cobbler::prerequisites {
 
   if $::osfamily == 'RedHat' {
-    package { 'epel-release': ensure  => present, }
+    if $cobbler::use_epel == true {
+      package { 'epel-release': ensure  => present, }
+    } else {
+      notify {'Don\'t using EPEL. Be sure that all needed packages available elsewhere.': }
+    }
   }
 
 }


### PR DESCRIPTION
- If you don't want to use EPEL e.g when holding cobbler in your private
  repository you can avoid it by setting use_epel to false
  
  class { 'cobbler':
    use_epel => false,
  }
