### PR TITLE
Remove puppetlabs-apache module from cobbler module

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,6 +6,3 @@ license 'Apache 2.0'
 summary 'Puppet module for Cobbler'
 description 'Module for Cobbler configuration'
 project_page 'https://bitbucket.org/jsosic/puppet-cobbler'
-
-## Add dependencies, if any:
-dependency 'puppetlabs/apache', '>= 0.5.0'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,13 +27,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define 'centos-6' do |centos|
     centos.vm.box = 'puppetlabs/centos-6.6-64-puppet'
-    centos.vm.provision 'shell', inline: 'puppet module install puppetlabs-apache'
     centos.vm.provision 'puppet' do |puppet|
       puppet.manifests_path = 'manifests'
       puppet.manifest_file = 'init.pp'
       puppet.options = [
           '--verbose',
-          "-e 'class { cobbler: }'"
+          "-e 'class { cobbler: } class { cobbler::web: }'"
       ]
     end
   end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,6 @@ class cobbler::config {
   }
   file { '/etc/httpd/conf.d/proxy_cobbler.conf':
     content => template('cobbler/proxy_cobbler.conf.erb'),
-    notify  => Service[$cobbler::apache_service],
   }
   
   file { $cobbler::distro_path :

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,12 +124,6 @@ class cobbler (
   $purge_system       = $cobbler::params::purge_system,
 ) inherits cobbler::params {
 
-  # require apache modules
-  include apache
-  include apache::mod::wsgi
-  include apache::mod::proxy
-  include apache::mod::proxy_http
-
   include cobbler::prerequisites
   include cobbler::install
   include cobbler::service

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -10,7 +10,6 @@
 class cobbler::web (
   $package_ensure = $cobbler::package_ensure,
 ) inherits cobbler {
-  require apache::mod::ssl
 
   package { 'cobbler-web':
     ensure => $package_ensure,
@@ -20,6 +19,6 @@ class cobbler::web (
     owner   => root,
     group   => root,
     mode    => '0644',
-    require => [ Package['cobbler-web'], Class['apache'], ],
+    require => [ Package['cobbler-web'] ],
   }
 }


### PR DESCRIPTION
- The cobbler package installs httpd as dependency so no need to
  pull in the puppetlabs-apache module. If you need to configure the httpd
  do it in your profile .
